### PR TITLE
Use milliseconds for timeout when checking for active workers

### DIFF
--- a/javascript/dist/queue/Supervisor.js
+++ b/javascript/dist/queue/Supervisor.js
@@ -23,6 +23,7 @@ class Supervisor extends BaseRunner_1.BaseRunner {
             timeLeft -= 1;
             await (0, utils_1.sleep)(1000);
             if (await this.workersAreActive()) {
+                console.log('Workers are active');
                 timeLeftWithNoWorkers = this.config.inactiveWorkersTimeout;
             }
             else {
@@ -35,7 +36,7 @@ class Supervisor extends BaseRunner_1.BaseRunner {
         return await this.isExhausted();
     }
     async workersAreActive() {
-        const zRangeByScoreArr = await this.client.zRangeByScore(this.key('running'), Date.now() - this.config.timeout, '+inf', {
+        const zRangeByScoreArr = await this.client.zRangeByScore(this.key('running'), Date.now() - this.config.timeout * 1000, '+inf', {
             LIMIT: { offset: 0, count: 1 },
         });
         return Number(zRangeByScoreArr[0]) > 0;

--- a/javascript/src/queue/Supervisor.ts
+++ b/javascript/src/queue/Supervisor.ts
@@ -27,6 +27,7 @@ export class Supervisor extends BaseRunner {
       await sleep(1000);
 
       if (await this.workersAreActive()) {
+        console.log('Workers are active');
         timeLeftWithNoWorkers = this.config.inactiveWorkersTimeout;
       } else {
         timeLeftWithNoWorkers -= 1;
@@ -42,7 +43,7 @@ export class Supervisor extends BaseRunner {
   private async workersAreActive() {
     const zRangeByScoreArr = await this.client.zRangeByScore(
       this.key('running'),
-      Date.now() - this.config.timeout,
+      Date.now() - this.config.timeout*1000,
       '+inf',
       {
         LIMIT: { offset: 0, count: 1 },


### PR DESCRIPTION
This fixes a bug where the timeout was not being converted to ms.