### PR TITLE
Change all time values to seconds

### DIFF
--- a/javascript/dist/queue/BaseRunner.js
+++ b/javascript/dist/queue/BaseRunner.js
@@ -29,7 +29,7 @@ class BaseRunner {
     }
     async isExpired() {
         const createdAt = await this.client.get(this.key('created-at'));
-        return createdAt ? Number(createdAt) + this.config.redisTTL + TEN_MINUTES < Date.now() : true;
+        return createdAt ? Number(createdAt) + this.config.redisTTL + TEN_MINUTES < (Date.now() / 1000) : true;
     }
     async maxTestsFailed() {
         if (!this.config.maxTestsAllowedToFail) {

--- a/javascript/dist/queue/Supervisor.js
+++ b/javascript/dist/queue/Supervisor.js
@@ -36,7 +36,7 @@ class Supervisor extends BaseRunner_1.BaseRunner {
         return await this.isExhausted();
     }
     async workersAreActive() {
-        const zRangeByScoreArr = await this.client.zRangeByScore(this.key('running'), Date.now() - this.config.timeout * 1000, '+inf', {
+        const zRangeByScoreArr = await this.client.zRangeByScore(this.key('running'), (Date.now() / 1000) - this.config.timeout, '+inf', {
             LIMIT: { offset: 0, count: 1 },
         });
         return zRangeByScoreArr.length > 0;

--- a/javascript/dist/queue/Worker.js
+++ b/javascript/dist/queue/Worker.js
@@ -79,10 +79,10 @@ class Worker extends BaseRunner_1.BaseRunner {
         return reservedTest;
     }
     async tryToReserveTest() {
-        return await this.client.reserve(this.key('queue'), this.key('running'), this.key('processed'), this.key('worker', this.config.workerId, 'queue'), this.key('owners'), Date.now());
+        return await this.client.reserve(this.key('queue'), this.key('running'), this.key('processed'), this.key('worker', this.config.workerId, 'queue'), this.key('owners'), Date.now() / 1000);
     }
     async tryToReserveLostTest() {
-        const lostTest = await this.client.reserveLost(this.key('running'), this.key('completed'), this.key('worker', this.config.workerId, 'queue'), this.key('owners'), Date.now(), this.config.timeout);
+        const lostTest = await this.client.reserveLost(this.key('running'), this.key('completed'), this.key('worker', this.config.workerId, 'queue'), this.key('owners'), Date.now() / 1000, this.config.timeout);
         return lostTest;
     }
     async push(tests) {

--- a/javascript/src/queue/BaseRunner.ts
+++ b/javascript/src/queue/BaseRunner.ts
@@ -35,7 +35,7 @@ export class BaseRunner {
 
   async isExpired(): Promise<boolean> {
     const createdAt = await this.client.get(this.key('created-at'));
-    return createdAt ? Number(createdAt) + this.config.redisTTL + TEN_MINUTES < Date.now() : true;
+    return createdAt ? Number(createdAt) + this.config.redisTTL + TEN_MINUTES < (Date.now() / 1000) : true;
   }
 
   async maxTestsFailed(): Promise<boolean> {

--- a/javascript/src/queue/Supervisor.ts
+++ b/javascript/src/queue/Supervisor.ts
@@ -43,7 +43,7 @@ export class Supervisor extends BaseRunner {
   private async workersAreActive() {
     const zRangeByScoreArr = await this.client.zRangeByScore(
       this.key('running'),
-      Date.now() - this.config.timeout*1000,
+      (Date.now() / 1000) - this.config.timeout,
       '+inf',
       {
         LIMIT: { offset: 0, count: 1 },

--- a/javascript/src/queue/Worker.ts
+++ b/javascript/src/queue/Worker.ts
@@ -125,7 +125,7 @@ export class Worker extends BaseRunner {
       this.key('processed'),
       this.key('worker', this.config.workerId, 'queue'),
       this.key('owners'),
-      Date.now(),
+      Date.now() / 1000,
     );
   }
 
@@ -135,7 +135,7 @@ export class Worker extends BaseRunner {
       this.key('completed'),
       this.key('worker', this.config.workerId, 'queue'),
       this.key('owners'),
-      Date.now(),
+      Date.now() / 1000,
       this.config.timeout,
     );
     return lostTest;


### PR DESCRIPTION
The ci-queue Redis scripts expect times in seconds, not ms.