### PR TITLE
Update keys for failed tests

### DIFF
--- a/javascript/dist/queue/BaseRunner.d.ts
+++ b/javascript/dist/queue/BaseRunner.d.ts
@@ -330,7 +330,7 @@ export declare class BaseRunner {
     maxTestsFailed(): Promise<boolean>;
     testFailedCount(): Promise<string | null>;
     recordFailedTest(testName: string, testSuite: string): Promise<void>;
-    recordPassingTest(testName: string): Promise<void>;
+    recordPassingTest(testName: string, testSuite: string): Promise<void>;
     getFailedTests(): Promise<string>;
     waitForMaster(): Promise<void>;
     getMasterStatus(): Promise<string | null>;

--- a/javascript/dist/queue/BaseRunner.js
+++ b/javascript/dist/queue/BaseRunner.js
@@ -42,13 +42,16 @@ class BaseRunner {
         return await this.client.get(this.key('test_failed_count'));
     }
     async recordFailedTest(testName, testSuite) {
+        const fullTestName = `${testName}:${testSuite}`;
         const payload = JSON.stringify({ test_name: testName, test_suite: testSuite });
-        await this.client.hSet(this.key('error-reports'), Buffer.from(testName).toString('binary'), Buffer.from(payload).toString('binary'));
+        await this.client.hSet(this.key('error-reports'), Buffer.from(fullTestName).toString('binary'), Buffer.from(payload).toString('binary'));
         await this.client.expire(this.key('error-reports'), this.config.redisTTL);
+        console.log(`Incrementing failed test count for ${testName}`);
         await this.client.incr(this.key('test_failed_count'));
     }
-    async recordPassingTest(testName) {
-        await this.client.hDel(this.key('error-reports'), Buffer.from(testName).toString('binary'));
+    async recordPassingTest(testName, testSuite) {
+        const fullTestName = `${testName}:${testSuite}`;
+        await this.client.hDel(this.key('error-reports'), Buffer.from(fullTestName).toString('binary'));
     }
     async getFailedTests() {
         const failedTests = await this.client.hGetAll(this.key('error-reports'));

--- a/javascript/src/queue/BaseRunner.ts
+++ b/javascript/src/queue/BaseRunner.ts
@@ -51,19 +51,22 @@ export class BaseRunner {
   }
 
   async recordFailedTest(testName: string, testSuite: string): Promise<void> {
+    const fullTestName = `${testName}:${testSuite}`;
     const payload = JSON.stringify({ test_name: testName, test_suite: testSuite });
     await this.client.hSet(
       this.key('error-reports'),
-      Buffer.from(testName).toString('binary'),
+      Buffer.from(fullTestName).toString('binary'),
       Buffer.from(payload).toString('binary')
     );
   
     await this.client.expire(this.key('error-reports'), this.config.redisTTL);
+    console.log(`Incrementing failed test count for ${testName}`);
     await this.client.incr(this.key('test_failed_count'));
   }
 
-  async recordPassingTest(testName: string): Promise<void> {
-    await this.client.hDel(this.key('error-reports'), Buffer.from(testName).toString('binary'));
+  async recordPassingTest(testName: string, testSuite: string): Promise<void> {
+    const fullTestName = `${testName}:${testSuite}`;
+    await this.client.hDel(this.key('error-reports'), Buffer.from(fullTestName).toString('binary'));
   }
 
   async getFailedTests(): Promise<string> {


### PR DESCRIPTION
This PR updates the key for failed tests to use the test + suite name