### PR TITLE
Have 60% of workers exit early

### DIFF
--- a/javascript/dist/queue/Worker.d.ts
+++ b/javascript/dist/queue/Worker.d.ts
@@ -16,4 +16,5 @@ export declare class Worker extends BaseRunner {
     private tryToReserveTest;
     private tryToReserveLostTest;
     private push;
+    private shouldShutdownEarly;
 }

--- a/javascript/dist/queue/Worker.js
+++ b/javascript/dist/queue/Worker.js
@@ -20,6 +20,11 @@ class Worker extends BaseRunner_1.BaseRunner {
                 yield test;
             }
             else {
+                const shouldShutdownEarly = await this.shouldShutdownEarly();
+                if (shouldShutdownEarly) {
+                    console.log(`[ci-queue] No more tests to pick up for now, will shutdown early`);
+                    break;
+                }
                 const now = Date.now() / 1000;
                 // Only log every 5s to reduce noise
                 if (now - lastLogTime > 5) {
@@ -122,6 +127,17 @@ class Worker extends BaseRunner_1.BaseRunner {
         }
         await this.client.sAdd(this.key('workers'), [this.config.workerId]);
         await this.client.expire(this.key('workers'), this.config.redisTTL);
+    }
+    async shouldShutdownEarly() {
+        const totalWorkers = await this.client.sMembers(this.key('workers'));
+        const totalWorkersCount = totalWorkers.length;
+        console.log("[ci-queue] Total workers count: ", totalWorkersCount);
+        const stayRunningThreshold = Math.min(Math.floor(totalWorkersCount * 0.6), 1);
+        console.log("[ci-queue] Threshold for early shutdown: ", stayRunningThreshold);
+        const parallelJob = parseInt(this.config.workerId, 10);
+        const shouldShutdownEarly = parallelJob > stayRunningThreshold;
+        console.log("[ci-queue] Parallel job: ", parallelJob, "Should shutdown early: ", shouldShutdownEarly);
+        return shouldShutdownEarly;
     }
 }
 exports.Worker = Worker;


### PR DESCRIPTION
Add check for whether a worker should exit early, rather than hanging around waiting to pick up more tests