### PR TITLE
Support dynamic test timeouts

### DIFF
--- a/javascript/dist/queue/BaseRunner.d.ts
+++ b/javascript/dist/queue/BaseRunner.d.ts
@@ -310,19 +310,20 @@ export declare class BaseRunner {
         reserve: {
             NUMBER_OF_KEYS: number;
             SCRIPT: string;
-            transformArguments(this: void, queueKey: string, setKey: string, processedKey: string, workerQueueKey: string, ownersKey: string, currentTime: number): string[];
+            transformArguments(this: void, queueKey: string, setKey: string, processedKey: string, workerQueueKey: string, ownersKey: string, testGroupTimeoutKey: string, currentTime: number, useDynamicDeadline: boolean): string[];
             transformReply(this: void, reply: string | null | undefined): string | null | undefined;
         } & import("@redis/client/dist/lib/lua-script").SHA1;
         reserveLost: {
             NUMBER_OF_KEYS: number;
             SCRIPT: string;
-            transformArguments(this: void, setKey: string, completedKey: string, workerQueueKey: string, ownersKey: string, currentTime: number, timeout: number): string[];
+            transformArguments(this: void, setKey: string, completedKey: string, workerQueueKey: string, ownersKey: string, testGroupTimeoutKey: string, currentTime: number, timeout: number, useDynamicDeadline: boolean): string[];
             transformReply(this: void, reply: string | null | undefined): string | null | undefined;
         } & import("@redis/client/dist/lib/lua-script").SHA1;
     }>;
     totalTestCount: number;
     private queueInitialized?;
     constructor(redisUrl: string, config: Configuration);
+    useDynamicDeadline(): boolean;
     connect(): Promise<void>;
     disconnect(): Promise<void>;
     isExhausted(): Promise<boolean>;
@@ -339,6 +340,7 @@ export declare class BaseRunner {
     size(): Promise<number>;
     progress(): Promise<number>;
     toArray(): Promise<string[]>;
+    testGroupTimeoutKey(): string;
     key(...args: string[]): string;
     retriedBuildKey(...args: string[]): string;
     private createRedisScripts;

--- a/javascript/dist/queue/Configuration.d.ts
+++ b/javascript/dist/queue/Configuration.d.ts
@@ -27,7 +27,8 @@ export declare class Configuration {
     namespace?: string;
     failureFile?: string;
     retriedBuildId?: string;
-    constructor({ buildId, workerId, seed, redisTTL, maxRequeues, requeueTolerance, maxTestsAllowedToFail, timeout, reportTimeout, inactiveWorkersTimeout, namespace, failureFile, retriedBuildId, }: {
+    useDynamicDeadline?: boolean;
+    constructor({ buildId, workerId, seed, redisTTL, maxRequeues, requeueTolerance, maxTestsAllowedToFail, timeout, reportTimeout, inactiveWorkersTimeout, namespace, failureFile, retriedBuildId, useDynamicDeadline, }: {
         buildId: string;
         workerId: string;
         seed?: string;
@@ -41,6 +42,7 @@ export declare class Configuration {
         namespace?: string;
         failureFile?: string;
         retriedBuildId?: string;
+        useDynamicDeadline?: boolean;
     });
     static fromEnv(): any;
     globalMaxRequeues(testCount: number): number;

--- a/javascript/dist/queue/Configuration.js
+++ b/javascript/dist/queue/Configuration.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Configuration = void 0;
 class Configuration {
-    constructor({ buildId, workerId, seed, redisTTL, maxRequeues, requeueTolerance, maxTestsAllowedToFail, timeout, reportTimeout, inactiveWorkersTimeout, namespace, failureFile, retriedBuildId, }) {
+    constructor({ buildId, workerId, seed, redisTTL, maxRequeues, requeueTolerance, maxTestsAllowedToFail, timeout, reportTimeout, inactiveWorkersTimeout, namespace, failureFile, retriedBuildId, useDynamicDeadline, }) {
         this.buildId = buildId;
         this.workerId = workerId;
         this.seed = seed;
@@ -16,6 +16,7 @@ class Configuration {
         this.namespace = namespace;
         this.failureFile = failureFile;
         this.retriedBuildId = retriedBuildId;
+        this.useDynamicDeadline = useDynamicDeadline ?? false;
     }
     static fromEnv() {
         const buildId = process.env['CIRCLE_BUILD_URL'] ||

--- a/javascript/dist/queue/Test.d.ts
+++ b/javascript/dist/queue/Test.d.ts
@@ -1,0 +1,4 @@
+export interface TestSpec {
+    name: string;
+    timeout: number;
+}

--- a/javascript/dist/queue/Test.js
+++ b/javascript/dist/queue/Test.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/javascript/dist/queue/Worker.d.ts
+++ b/javascript/dist/queue/Worker.d.ts
@@ -1,5 +1,6 @@
 import { BaseRunner } from './BaseRunner';
 import { Configuration } from './Configuration';
+import { TestSpec } from './Test';
 export declare class Worker extends BaseRunner {
     private shutdownRequired;
     private currentlyReservedTest;
@@ -9,7 +10,7 @@ export declare class Worker extends BaseRunner {
     acknowledge(test: string): Promise<boolean>;
     requeue(test: string, offset?: number): Promise<boolean>;
     release(): Promise<void>;
-    populate(tests: string[], seed?: number): Promise<boolean>;
+    populate(tests: TestSpec[], seed?: number): Promise<boolean>;
     shutdown(): void;
     private throwOnMismatchingTest;
     private reserveTest;

--- a/javascript/dist/queue/Worker.js
+++ b/javascript/dist/queue/Worker.js
@@ -74,7 +74,18 @@ class Worker extends BaseRunner_1.BaseRunner {
                 return false;
             }
             console.log(`[ci-queue] Failed test groups: ${failedTestGroups}`);
-            await this.push(failedTestGroups);
+            const failedTestGroupTimeouts = [];
+            for (const failedTestGroup of failedTestGroups) {
+                const testSpec = tests.find((test) => test.name === failedTestGroup);
+                if (testSpec) {
+                    failedTestGroupTimeouts.push(testSpec);
+                }
+                else {
+                    console.log("Failed to find timeout for test group", failedTestGroup, ". defaulting to", this.config.timeout);
+                    failedTestGroupTimeouts.push({ name: failedTestGroup, timeout: this.config.timeout });
+                }
+            }
+            await this.push(failedTestGroupTimeouts);
             return true;
         }
         console.log(`[ci-queue] Populating tests`);
@@ -105,24 +116,31 @@ class Worker extends BaseRunner_1.BaseRunner {
         return reservedTest;
     }
     async tryToReserveTest() {
-        return await this.client.reserve(this.key('queue'), this.key('running'), this.key('processed'), this.key('worker', this.config.workerId, 'queue'), this.key('owners'), Date.now() / 1000);
+        return await this.client.reserve(this.key('queue'), this.key('running'), this.key('processed'), this.key('worker', this.config.workerId, 'queue'), this.key('owners'), this.testGroupTimeoutKey(), Date.now() / 1000, this.useDynamicDeadline());
     }
     async tryToReserveLostTest() {
-        const lostTest = await this.client.reserveLost(this.key('running'), this.key('completed'), this.key('worker', this.config.workerId, 'queue'), this.key('owners'), Date.now() / 1000, this.config.timeout);
+        const lostTest = await this.client.reserveLost(this.key('running'), this.key('completed'), this.key('worker', this.config.workerId, 'queue'), this.key('owners'), this.testGroupTimeoutKey(), Date.now() / 1000, this.config.timeout, this.useDynamicDeadline());
         return lostTest;
     }
-    async push(tests) {
+    async push(testSpecs) {
+        const tests = testSpecs.map((testSpec) => testSpec.name);
+        const testTimeoutMap = testSpecs.reduce((acc, testSpec) => {
+            acc[testSpec.name] = testSpec.timeout;
+            return acc;
+        }, {});
         this.totalTestCount = tests.length;
         this.isMaster = await this.client.setNX(this.key('master-status'), 'setup');
         if (this.isMaster) {
             await this.client
                 .multi()
                 .lPush(this.key('queue'), tests)
+                .hSet(this.testGroupTimeoutKey(), testTimeoutMap)
                 .set(this.key('total'), this.totalTestCount)
                 .set(this.key('master-status'), 'ready')
                 .expire(this.key('queue'), this.config.redisTTL)
                 .expire(this.key('total'), this.config.redisTTL)
                 .expire(this.key('master-status'), this.config.redisTTL)
+                .expire(this.testGroupTimeoutKey(), this.config.redisTTL)
                 .exec();
         }
         await this.client.sAdd(this.key('workers'), [this.config.workerId]);

--- a/javascript/src/queue/Configuration.ts
+++ b/javascript/src/queue/Configuration.ts
@@ -28,6 +28,7 @@ export class Configuration {
   namespace?: string;
   failureFile?: string;
   retriedBuildId?: string;
+  useDynamicDeadline?: boolean;
   constructor({
     buildId,
     workerId,
@@ -42,6 +43,7 @@ export class Configuration {
     namespace,
     failureFile,
     retriedBuildId,
+    useDynamicDeadline,
   }: {
     buildId: string;
     workerId: string;
@@ -56,6 +58,7 @@ export class Configuration {
     namespace?: string;
     failureFile?: string;
     retriedBuildId?: string;
+    useDynamicDeadline?: boolean;
   }) {
     this.buildId = buildId;
     this.workerId = workerId;
@@ -70,6 +73,7 @@ export class Configuration {
     this.namespace = namespace;
     this.failureFile = failureFile;
     this.retriedBuildId = retriedBuildId;
+    this.useDynamicDeadline = useDynamicDeadline ?? false
   }
 
   static fromEnv() {

--- a/javascript/src/queue/Test.ts
+++ b/javascript/src/queue/Test.ts
@@ -1,0 +1,4 @@
+export interface TestSpec {
+  name: string;
+  timeout: number;
+}

--- a/javascript/src/queue/Worker.ts
+++ b/javascript/src/queue/Worker.ts
@@ -1,6 +1,7 @@
 import { BaseRunner } from './BaseRunner';
 import { Configuration } from './Configuration';
 import { shuffleArray, sleep } from './utils';
+import { TestSpec } from './Test';
 
 export class Worker extends BaseRunner {
   private shutdownRequired: boolean = false;
@@ -97,7 +98,7 @@ export class Worker extends BaseRunner {
     );
   }
 
-  async populate(tests: string[], seed?: number): Promise<boolean> {
+  async populate(tests: TestSpec[], seed?: number): Promise<boolean> {
     if (this.config.retriedBuildId) {
       console.log(`[ci-queue] Retrying failed tests for build ${this.config.retriedBuildId}`);
       const failedTestGroups = await this.getFailedTestGroupsFromPreviousBuild();
@@ -106,7 +107,17 @@ export class Worker extends BaseRunner {
         return false;
       }
       console.log(`[ci-queue] Failed test groups: ${failedTestGroups}`);
-      await this.push(failedTestGroups);
+      const failedTestGroupTimeouts: TestSpec[] = []
+      for (const failedTestGroup of failedTestGroups) {
+        const testSpec = tests.find((test) => test.name === failedTestGroup)
+        if (testSpec) {
+          failedTestGroupTimeouts.push(testSpec)
+        } else {
+          console.log("Failed to find timeout for test group", failedTestGroup, ". defaulting to", this.config.timeout)
+          failedTestGroupTimeouts.push({ name: failedTestGroup, timeout: this.config.timeout })
+        }
+      }
+      await this.push(failedTestGroupTimeouts);
       return true;
     }
 
@@ -153,7 +164,9 @@ export class Worker extends BaseRunner {
       this.key('processed'),
       this.key('worker', this.config.workerId, 'queue'),
       this.key('owners'),
-      Date.now() / 1000 + this.config.timeout,
+      this.testGroupTimeoutKey(),
+      Date.now() / 1000,
+      this.useDynamicDeadline(),
     );
   }
 
@@ -163,24 +176,34 @@ export class Worker extends BaseRunner {
       this.key('completed'),
       this.key('worker', this.config.workerId, 'queue'),
       this.key('owners'),
+      this.testGroupTimeoutKey(),
       Date.now() / 1000,
-      Date.now() / 1000 + this.config.timeout,
+      this.config.timeout,
+      this.useDynamicDeadline(),
     );
     return lostTest;
   }
 
-  private async push(tests: any[]) {
+  private async push(testSpecs: TestSpec[]) {
+    const tests = testSpecs.map((testSpec) => testSpec.name)
+    const testTimeoutMap: Record<string, number> = testSpecs.reduce((acc: Record<string, number>, testSpec: TestSpec) => {
+      acc[testSpec.name] = testSpec.timeout;
+      return acc;
+    }, {})
+
     this.totalTestCount = tests.length;
     this.isMaster = await this.client.setNX(this.key('master-status'), 'setup');
     if (this.isMaster) {
       await this.client
         .multi()
         .lPush(this.key('queue'), tests)
+        .hSet(this.testGroupTimeoutKey(), testTimeoutMap)
         .set(this.key('total'), this.totalTestCount)
         .set(this.key('master-status'), 'ready')
         .expire(this.key('queue'), this.config.redisTTL)
         .expire(this.key('total'), this.config.redisTTL)
         .expire(this.key('master-status'), this.config.redisTTL)
+        .expire(this.testGroupTimeoutKey(), this.config.redisTTL)
         .exec();
     }
     await this.client.sAdd(this.key('workers'), [this.config.workerId]);

--- a/redis/reserve.lua
+++ b/redis/reserve.lua
@@ -3,12 +3,19 @@ local zset_key = KEYS[2]
 local processed_key = KEYS[3]
 local worker_queue_key = KEYS[4]
 local owners_key = KEYS[5]
+local test_group_timeout_key = KEYS[6]
 
-local deadline = ARGV[1]
+local current_time = ARGV[1]
+local use_dynamic_deadline = ARGV[2] == "true"
 
 local test = redis.call('rpop', queue_key)
 if test then
-  redis.call('zadd', zset_key, deadline, test)
+  if use_dynamic_deadline then
+    local dynamic_timeout = redis.call('hget', test_group_timeout_key, test)
+    redis.call('zadd', zset_key, current_time + dynamic_timeout, test)
+  else
+    redis.call('zadd', zset_key, current_time, test)
+  end
   redis.call('lpush', worker_queue_key, test)
   redis.call('hset', owners_key, test, worker_queue_key)
   return test

--- a/redis/reserve_lost.lua
+++ b/redis/reserve_lost.lua
@@ -2,14 +2,27 @@ local zset_key = KEYS[1]
 local processed_key = KEYS[2]
 local worker_queue_key = KEYS[3]
 local owners_key = KEYS[4]
+local test_group_timeout_key = KEYS[5]
 
 local current_time = ARGV[1]
-local deadline = ARGV[2]
+local timeout = ARGV[2]
+local use_dynamic_deadline = ARGV[3] == "true"
 
-local lost_tests = redis.call('zrangebyscore', zset_key, 0, current_time)
+local lost_tests
+if use_dynamic_deadline then
+  lost_tests = redis.call('zrangebyscore', zset_key, 0, current_time)
+else
+  lost_tests = redis.call('zrangebyscore', zset_key, 0, current_time - timeout)
+end
+
 for _, test in ipairs(lost_tests) do
   if redis.call('sismember', processed_key, test) == 0 then
-    redis.call('zadd', zset_key, deadline, test)
+    if use_dynamic_deadline then
+      local dynamic_timeout = redis.call('hget', test_group_timeout_key, test)
+      redis.call('zadd', zset_key, current_time + dynamic_timeout, test)
+    else
+      redis.call('zadd', zset_key, current_time, test)
+    end
     redis.call('lpush', worker_queue_key, test)
     redis.call('hset', owners_key, test, worker_queue_key) -- Take ownership
     return test


### PR DESCRIPTION
This PR supports dynamic test timeouts. This is all flagged behind the `useDynamicDeadline` flag in `Configuration`.

## How does it work?
- `.populate()` on the worker now expects a `TestSpec` which is both a test group name as well as a `timeout` value. A mapping of test group name -> timeout is added to redis once tests are populated.
- When `pollIter()` is called to reserve a non-lost test, our Lua script gets the next test group in the `queue` and adds it to the `running` set with a deadline of `current_time + timeout`. `current_time` is passed in from JS and `timeout` is fetched from the Redis mapping of test group name -> timeout in Lua.
- When `pollIter()` is called to reserve a lost test, our Lua script pulls all the tests where the `current_time` is greater than the deadline in the `running` set. It pulls off the first one and then adjusts the deadline by taking `current_time + timeout`. Again, `timeout` is fetched from the Redis mapping of test group name -> timeout in Lua.

## Test Plan
Tbh, it feels a bit tricky to test all the different edge cases locally, but I was able to get it set up and it seems to be running tests in the right order. I'm hoping to do more thorough testing once we bump the `ci-queue` version in `integration-tests`