### PR TITLE
Write to stdout every 5 minutes on master processes

### DIFF
--- a/javascript/src/queue/Worker.ts
+++ b/javascript/src/queue/Worker.ts
@@ -12,6 +12,7 @@ export class Worker extends BaseRunner {
 
   async *pollIter() {
     let lastLogTime = 0;
+    let lastHeartbeatTime = Date.now() / 1000;
     await this.waitForMaster();
     while (
       !this.shutdownRequired &&
@@ -34,6 +35,12 @@ export class Worker extends BaseRunner {
         if (now - lastLogTime > 5) {
           console.log('[ci-queue] No test to reserve, sleeping');
           lastLogTime = now;
+        }
+
+        // Log heartbeat every 5 minutes if this is the master process
+        if (this.isMaster && now - lastHeartbeatTime > 300) {
+          console.log('[ci-queue] Still working');
+          lastHeartbeatTime = now;
         }
         await sleep(500);
       }

--- a/ruby/lib/ci/queue/redis/worker.rb
+++ b/ruby/lib/ci/queue/redis/worker.rb
@@ -50,10 +50,16 @@ module CI
 
         def poll
           wait_for_master
+          last_heartbeat_time = Time.now
           until shutdown_required? || config.circuit_breakers.any?(&:open?) || exhausted? || max_test_failed?
             if test = reserve
               yield index.fetch(test)
             else
+              # Log heartbeat every 5 minutes if this is the master process
+              if master? && Time.now - last_heartbeat_time > 300
+                puts '[ci-queue] Still working'
+                last_heartbeat_time = Time.now
+              end
               sleep 0.05
             end
           end


### PR DESCRIPTION
[#sev-3-2025-05-20-sinatra-opensearch-ci-749581](https://figma.enterprise.slack.com/archives/C08TB5QK6BW)

We're seeing an issue where the master job times out due to `receiving no output for 20m0s`. Remedy this by writing to stdout every 5 minutes.