### PR TITLE
Print requeued tests

### DIFF
--- a/ruby/lib/ci/queue/redis/build_record.rb
+++ b/ruby/lib/ci/queue/redis/build_record.rb
@@ -21,6 +21,13 @@ module CI
           redis.hkeys(key('error-reports'))
         end
 
+        TOTAL_KEY = "___total___"
+        def requeued_tests
+          requeues = redis.hgetall(key('requeues-count'))
+          requeues.delete(TOTAL_KEY)
+          requeues
+        end
+
         def pop_warnings
           warnings = redis.multi do |transaction|
             transaction.lrange(key('warnings'), 0, -1)

--- a/ruby/lib/minitest/queue/build_status_reporter.rb
+++ b/ruby/lib/minitest/queue/build_status_reporter.rb
@@ -21,10 +21,20 @@ module Minitest
         build.flaky_reports
       end
 
+      def requeued_tests
+        build.requeued_tests
+      end
+
       def report
         puts aggregates
         errors = error_reports
         puts errors
+
+        requeued_tests.to_a.sort.each do |test_id, count|
+          puts yellow("REQUEUE")
+          puts "#{test_id} (requeued #{count} times)"
+          puts ""
+        end
 
         errors.empty?
       end


### PR DESCRIPTION
I have a sneaking suspicion that the max_requeues option isn't working as expected. See [this example](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Apipeline%20%40ci.pipeline.number%3A4638981&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=cipipeline&start=1756866759426&end=1757471559426&paused=false) in Datadog where the same failing test is run over 100 times for the same build ID

Anyway, it would be helpful to see when a test requeued to see if this is true. 

I [cherry-picked](https://github.com/Shopify/ci-queue/commit/233298a2c42971ed3068dc83d97951eac8e9f4c7) this from a commit in the original shopify/ci-queue repo